### PR TITLE
add additional parameters to htmlproofer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ addons:
     packages:
     - libcurl4-openssl-dev # required to avoid SSL errors
 script:
- - gem install html-proofer && htmlproofer .
+ - gem install html-proofer && htmlproofer .  --check-favicon --check-html --check-img-http


### PR DESCRIPTION
Default options don't include a lot of checks

Enables checking of favicon, html, and imgs

Issue #80