### PR TITLE
docs(CONTRIBUTING.md): add instructions for testing changes locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,10 @@ Every person on RiC should have an open [Issue](https://github.com/restincode/re
 
 If you cannot find the person, you can add them using our Issue [template](https://github.com/restincode/restincode/issues/new?assignees=&labels=Add+Person%2C+Needs+Review%2C+People&template=add-new-person-to-site.md&title=) template.
 
+### Testing your changes locally
+
+Using the provided Gemfile you can test locally by running ```bundle install``` and executing ```bundle exec jekyll serve``` to run a local web server on http://localhost:4000. Please verify your changes before submitting a Pull Request.
+
 ## Maintainers
 
 Maintainers are the people who have commit access to the RestInCode repository and can manage Issues and Pull Requests.

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ desc 'Check links for site already running on localhost:4000'
 task :check_links do
   begin
     require 'anemone'
-    root = 'http://192.168.12.241:4000/'
+    root = 'http://localhost:4000/'
     Anemone.crawl(root, :discard_page_bodies => true) do |anemone|
       anemone.after_crawl do |pagestore|
         broken_links = Hash.new { |h, k| h[k] = [] }


### PR DESCRIPTION
fix(Rakefile): update root URL for link checking task to use localhost The CONTRIBUTING.md file now includes instructions for testing changes locally using the provided Gemfile. Contributors can run `bundle install` and `bundle exec jekyll serve` to start a local web server on http://localhost:4000 and verify their changes before submitting a Pull Request.

The Rakefile has been updated to fix the root URL used in the link checking task. It now uses 'http://localhost:4000/' instead of 'http://192.168.12.241:4000/' to correctly check links on the local development server.