### PR TITLE
chore(.pre-commit-config.yaml): remove unused pre-commit hook configu…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,0 @@
-repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.3.0
-  hooks:
-    - id: no-commit-to-branch
-      args: ['--branch', 'main']


### PR DESCRIPTION
…ration

The .pre-commit-config.yaml file was deleted as it contained an unused pre-commit hook configuration. This removal helps to keep the repository clean and avoids confusion or unnecessary overhead when running pre-commit checks.