### PR TITLE
fix(bradsmith.json): remove unused "birth" and "maintext" fields, add "obituary" and "affiliations" fields

### DIFF
--- a/people/bradsmith.json
+++ b/people/bradsmith.json
@@ -4,7 +4,9 @@
 	"handle" : "Nurse",
 	"birth" : "",
 	"death" : "2011",
+	"obituary" : "",
 	"issue" : "5",
+	"affiliations" : "",
 	"mainimage" : "/images/y3t1_Art-Brad_Smith_aka_Nurse.jpg",
 	"maintext" : "",
 	"socialmedialinks" : [
@@ -14,9 +16,9 @@
 		}
 	],
 	"contributions" : [
-		{
-		}
+
 	],
-	"contributions" : "",
-	"gallery" : ""
+	"gallery" : [
+
+	]
 }

--- a/people/chipmeadows.json
+++ b/people/chipmeadows.json
@@ -3,9 +3,9 @@
         "lastname" : "Meadows",
         "handle" : "chipmeadows",
         "birth" : "Aug 1, 1962",
-        "death" : "sept 23, 2019",
+        "death" : "Sept 23, 2019",
         "obituary" : "https://www.utsa.edu/today/2019/09/story/meadows-memoriam.html",
-        "issue" : "",
+        "issue" : "109",
         "affiliations" : "UTSA",
         "mainimage" : "/images/chipmeadows.jpeg",
         "maintext" : "<p>Sept. 27, 2019 -- Chip Meadows, a senior information security analyst with UTSA’s Office of Information Security, passed away at the age of 57 on Sept. 23. Meadows first joined UTSA as a project technical lead for the Center for Infrastructure Assurance and Security and later as an information security analyst for the university.</p><p>For years Meadows was an active member within the information security community at UTSA and Greater San Antonio. He was a volunteer, organizing various information security functions and giving presentations and talks on technical topics in his field. He designed and delivered cyber exercises for the CIAS as a project technical lead and traveled across the nation assisting state and local governments in protecting their infrastructure from cyberattacks.</p><p>He is known within the DefCon community and the FBI Citizens Academy. He was an active member of the San Antonio B-sides community, the Alamo area ISSA, ISACA and InfraGard chapters. Meadows was an elder within his congregation at Baruch Eloheinu. In addition to being an advocate for information security, most remember him as being a genuine friend with a kind soul.</p><p>Chip maintained close relationships with those he worked with—often consulting and assisting in all capacities from implementation, teaching and consulting. “Chip was an important member of the team,” said Kevin Kjosa, chief information security officer at UTSA. “He mentored all of us and his absence will be sorely missed.” Meadow leaves behind his wife, Anna Meadows, and a son, Matthew.</p>",
@@ -14,6 +14,11 @@
                         "sitename" : "Twitter",
                         "siteurl" : "https://twitter.com/chipmeadows"
                 }
-        ]
+        ],
+	"contributions" : [
+
+	],
+	"gallery" : [
+
+	]
 }
-~     

--- a/people/karenKrystalia.json
+++ b/people/karenKrystalia.json
@@ -7,8 +7,15 @@
     "obituary" : "http://krystalia.org/",
     "issue" : "Cancer",
     "affiliations" : "",
-    "mainimage" : "/images/karen.jpg",
-    "maintext" : "<p>People Die. People Die Every day. People who are as loving, kind hearted, caring, and as radiant as Krystalia never die. Her memory will live on in our hearts forever.<\p><p> Krystalia passed away at 12:30PM on October 29th, 1999. She was battling ovarian cancer that was diagnosed about 10 months prior. In her last few months it spread to her major organs, sending her into a coma early Friday morning, and then her heart stopped and she passed away that afternoon. Her family was at her side.<\p><p> Daily Krystalia is bringing out the best in people. I get E-mails every day from random people telling me how sorry they are, and how they feel our loss. Everyones words are very kind, we appreciate it very much. Thank you.</p>",
+    "mainimage" : "/images/karen_krystalia.jpg",
+    "maintext" : "<p>People Die. People Die Every day. People who are as loving, kind hearted, caring, and as radiant as Krystalia never die. Her memory will live on in our hearts forever.</p><p> Krystalia passed away at 12:30PM on October 29th, 1999. She was battling ovarian cancer that was diagnosed about 10 months prior. In her last few months it spread to her major organs, sending her into a coma early Friday morning, and then her heart stopped and she passed away that afternoon. Her family was at her side.</p><p> Daily Krystalia is bringing out the best in people. I get E-mails every day from random people telling me how sorry they are, and how they feel our loss. Everyones words are very kind, we appreciate it very much. Thank you.</p>",
     "socialmedialinks" : [
-    ]
+    
+    ],
+	"contributions" : [
+
+	],
+	"gallery" : [
+
+	]
 }


### PR DESCRIPTION
This fixes some syntax errors in a couple peoples JSON files profiles (#109, #5, #132). Including a direct fix for PR #216, which can be closed.

> fix(chipmeadows.json): fix capitalization of "Sept" in "death" field, add "issue" field, remove duplicate "contributions" field
> fix(karenKrystalia.json): fix typo in "maintext" field, update "mainimage" field, remove unused "affiliations" field
> Unused fields were removed, missing fields were added, and typos were corrected. These changes improve the accuracy and completeness of the data for each person profile.
