### PR TITLE
chore(.pre-commit-config.yaml): update prettier hook to version 3.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
 #    -   id: jekyll-relative-url-check-html
 #    -   id: jekyll-relative-url-check-markdown
 -   repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.0
     hooks:
     -   id: prettier
         types: [json]


### PR DESCRIPTION
The prettier hook in the .pre-commit-config.yaml file has been updated
to version 3.0.0. This update may include bug fixes, new features, or
other improvements provided by the new version of the prettier hook.