### PR TITLE
chore(.pre-commit-config.yaml): enable autofixing pull-request commits by pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,4 @@ repos:
     -   id: prettier
         types: [json]
 ci:
-    autofix_prs: false
+    autofix_prs: true # set false to stop pull-request commits being added by pre-commit.ci


### PR DESCRIPTION
The `autofix_prs` option in the `ci` section of the
`.pre-commit-config.yaml` file is set to `true` to allow pre-commit.ci
to automatically add commits for pull requests. This change enables the
automatic fixing of issues identified by pre-commit hooks in pull
requests.