### PR TITLE
chore(pre-commit-config.yaml): exclude 'CNAME' file from pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 # .pre-commit-config.yaml
+exclude: 'CNAME'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0  # use `pre-commit autoupdate` to get the latest rev


### PR DESCRIPTION
The 'CNAME' file is now excluded from pre-commit checks to prevent
unnecessary checks and avoid false positives.