### PR TITLE
feat(update_contributors.yml): add workflow to automatically update contributors in README

### DIFF
--- a/.github/workflows/update_contributors.yml
+++ b/.github/workflows/update_contributors.yml
@@ -1,0 +1,21 @@
+# Inserts list of community members into ./README.md
+name: Add contributors to README
+on:
+  workflow_dispatch: # Manual dispatch
+  schedule:
+    - cron: '10 2 * * 0' # At 02:10 on Sunday.
+
+jobs:
+  insert-contributors:
+    runs-on: ubuntu-latest
+    name: Add contributors
+    steps:
+      - name: Updates readme with contributors
+        uses: akhilmhdh/contributors-readme-action@v2.3.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        with:
+          image_size: 80
+          readme_path: .github/README.md
+          columns_per_row: 6
+          commit_message: 'chore(README.md): updates contributors list'

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ This project is intended to be open to all and a true community effort. Everyone
 
 Please see our [CONTRIBUTING](https://github.com/restincode/restincode/blob/main/CONTRIBUTING.md) guide for instructions on how to help this project grow.
 
+## Contributors
+
+<!-- readme: collaborators,contributors -start -->
+<!-- readme: collaborators,contributors -end -->
+
 <p align="center">
   <p align="center">
     <a href="https://twitter.com/intent/follow?screen_name=restincode"><img src="https://img.shields.io/twitter/follow/restincode?style=social&logo=twitter" alt="follow on Twitter"></a> &nbsp;


### PR DESCRIPTION
chore(README.md): updates contributors list
- The update_contributors.yml workflow has been added to automatically update the list of contributors in the README.md file.
- This workflow runs on a schedule every Sunday at 02:10 and also allows for manual dispatch.
- The workflow uses the contributors-readme-action to insert the list of community members into the README.md file.

The commit message for the update is "chore(README.md): updates contributors list". This ensures that the contributors list is always up to date and reflects the current community members contributing to the project.