### PR TITLE
Add .envrc and .gitignore_local to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 _site
 .bundle
 vendor
+
+# Local environment and configuration
+.envrc
+.gitignore_local


### PR DESCRIPTION
Adds local environment and configuration files to .gitignore to prevent them from being committed.

## Summary by Sourcery

Chores:
- Add .envrc and .gitignore_local patterns to .gitignore to avoid committing local config files.