### PR TITLE
fix(data): add missing URLs and data from issue comments

### DIFF
--- a/people/aaronswartz.json
+++ b/people/aaronswartz.json
@@ -17,6 +17,14 @@
     {
       "sitename": "Website",
       "siteurl": "http://www.aaronsw.com/"
+    },
+    {
+      "sitename": "Wikipedia",
+      "siteurl": "https://en.wikipedia.org/wiki/Aaron_Swartz"
+    },
+    {
+      "sitename": "MuckRock FOIA",
+      "siteurl": "https://www.muckrock.com/foi/united-states-of-america-10/aaron-swartz-fbi-2484/"
     }
   ],
   "contributions": [

--- a/people/benbyer.json
+++ b/people/benbyer.json
@@ -10,6 +10,12 @@
   "mainimage": "/images/byer-ben.jpg",
   "maintext": "<p>We are deeply saddened by the news that our member, colleague, and friend Ben “bushing” Byer passed away of natural causes on Monday, February 8th. Many of you knew him as one of the public faces of our group, fail0verflow, and before that, Team Twiizers and the iPhone Dev Team. Outspoken but never confrontational, he was proof that even in the competitive and oftentimes aggressive hacking scene, there is a place for both a sharp mind and a kind heart. To us he was, of course, much more. He brought us together, as a group and in spirit. Without him, we as a team would not exist. He was a mentor to many, and an inspiration to us all. Yet above anything, he was our friend. He will be dearly missed. Our thoughts go out to his wife and family. Keep hacking. It’s what bushing would have wanted. </p>",
   "socialmedialinks": [],
-  "contributions": [],
+  "contributions": [
+    {
+      "title": "fail0verflow memorial",
+      "url": "https://fail0verflow.com/blog/2016/ben/",
+      "description": "fail0verflow's memorial blog post for Ben 'bushing' Byer."
+    }
+  ],
   "gallery": []
 }

--- a/people/bruceesquibel.json
+++ b/people/bruceesquibel.json
@@ -42,6 +42,16 @@
       "url": "/images/bruce_esquibel2.jpg",
       "title": "Dr. Ripco and Jason Scott with the original Apple II Ripco BBS ran on.",
       "caption": "Dr. Ripco and Jason Scott with the original Apple II Ripco BBS ran on."
+    },
+    {
+      "url": "https://twitter.com/textfiles/status/1625878219114127362",
+      "title": "textfiles memorial tweet",
+      "caption": ""
+    },
+    {
+      "url": "https://twitter.com/DethVeggie/status/1626016692613812224",
+      "title": "DethVeggie memorial tweet",
+      "caption": ""
     }
   ]
 }

--- a/people/chrishurley.json
+++ b/people/chrishurley.json
@@ -6,7 +6,7 @@
   "death": "2023-01-21",
   "obituary": "https://web.archive.org/web/20230129033108/https://www.dignitymemorial.com/obituaries/san-diego-ca/christopher-hurley-11124704",
   "issue": "192",
-  "affiliations": "DEF CON, DC 303, DEF CON 101, WorldWide WarDrive, Department of Energy, Sony PlayStation",
+  "affiliations": "DEF CON, DC 303, DEF CON 101, WorldWide WarDrive, Security Tribe, Goon Band, Department of Energy, Sony PlayStation",
   "mainimage": "/images/chrishurley00.jpg",
   "maintext": "Appearing in a cloud of (cigarette) smoke, Roamer is a man full of whiskey and ideas. He has appeared at DEF CON since before (almost) the beginning. He is a renowned author, speaker, pontificator and is famous for giving the most entertaining Worldwide Wardrive talk. He is also the Grand Vizier of All Things Vendor-you are welcome. When Roamer speaks, people listen. And often fall in love.",
   "socialmedialinks": [

--- a/people/christianwright.json
+++ b/people/christianwright.json
@@ -19,6 +19,18 @@
       "siteurl": "https://www.facebook.com/groups/359810421318698/"
     }
   ],
-  "contributions": [],
-  "gallery": []
+  "contributions": [
+    {
+      "title": "SecLists ISN Posting",
+      "url": "https://seclists.org/isn/2019/May/33",
+      "description": "SecLists ISN posting about Christian Wright."
+    }
+  ],
+  "gallery": [
+    {
+      "url": "https://www.gofundme.com/in-memory-of-christian-wright",
+      "title": "GoFundMe memorial page",
+      "caption": ""
+    }
+  ]
 }

--- a/people/dankaminsky.json
+++ b/people/dankaminsky.json
@@ -36,5 +36,26 @@
       "description": "Full 30-minute interview with Dan Kaminsky about DEF CON, speaking at hacking cons, and what makes them special. Released from the vaults by @textfiles with permission from @thedarktangent."
     }
   ],
-  "gallery": []
+  "gallery": [
+    {
+      "url": "https://www.nytimes.com/2021/04/27/technology/daniel-kaminsky-dead.html",
+      "title": "New York Times obituary",
+      "caption": ""
+    },
+    {
+      "url": "https://it.slashdot.org/story/21/04/24/1645214/security-researcher-dan-kaminsky-has-died",
+      "title": "Slashdot article",
+      "caption": ""
+    },
+    {
+      "url": "https://www.the-parallax.com/cybersleuth-dan-kaminsky-medical-answers/",
+      "title": "The Parallax article",
+      "caption": ""
+    },
+    {
+      "url": "https://twitter.com/_videoman_/status/1386126728767102977",
+      "title": "List of Dan Kaminsky's talks",
+      "caption": ""
+    }
+  ]
 }

--- a/people/geoffreybennett.json
+++ b/people/geoffreybennett.json
@@ -6,10 +6,16 @@
   "death": "2008",
   "obituary": "https://www.dignitymemorial.com/obituaries/austin-tx/geoffrey-bennett-8211772",
   "issue": "33",
-  "affiliations": "AHA!",
+  "affiliations": "AHA!, TICOM, Inc.",
   "mainimage": "/images/Geoffrey_Bennett.jpg",
   "maintext": "<p>From Obituary: Geoffrey Southerland Bennett On April 6, 2008, Geoffrey Southerland Bennett, passed away while jogging at the Dell Jewish Community Center of Austin. Born in Washington, D.C. on August 22, 1966, Geoff was 41 years old. Geoffrey was a very loving and nurturing father to his daughter, Ruthie. He produced 'Ruthie's Daily Grind', an internet blog on Ruthie's development from infancy through preschool.</p><p>Geoffrey graduated from Austin High School and was an outstanding gymnast in high school and college. While attending Austin High, he held all but one of the men's gymnastic records. Geoffrey earned a BFA degree at the University of Oklahoma and was an accomplished artist. Geoff was an avid reader with a passion for satire. He was employed by TICOM, Inc., and was a highly regarded Information Systems Security Analyst and Network Administrator.</p><p>Survivors include his daughter, Ruth Lynelle Bennett; wife, Jennifer Godfrey Bennett; mother, Mary Beth Bennett; father, Baylus Bennett; brother, Chad Bennett and his wife Catherine and their children Cadyn and Chase Bennett. Visitation will be held Wednesday April 9, from 6:00 – 8:00 p.m. at Weed-Corley-Fish Funeral Home, 3125 N. Lamar. Services will be held at 1 pm on Thursday, April 10, at Weed-Corley-Fish Funeral Home. Interment will follow at Austin Memorial Park. Pallbearers are: Chad Bennett, Raymond Bennett, Willie Bennett, Bruce Tabor, Kevin Godfrey, Ian Robertson, Jason Johnston, and Aqueel Darbar. In lieu of flowers contributions to the following organizations are welcome, Dell Children's Hospital, Town Lake Animal Center, and Capitol School of Austin</p>",
   "socialmedialinks": [],
-  "contributions": [],
+  "contributions": [
+    {
+      "title": "Open letter to DOJ re: Microsoft Settlement",
+      "url": "http://www.kegel.com/remedy/letter.html",
+      "description": "Geoffrey signed the open letter to the DOJ regarding the Microsoft Settlement."
+    }
+  ],
   "gallery": []
 }

--- a/people/glenneccard.json
+++ b/people/glenneccard.json
@@ -16,5 +16,21 @@
     }
   ],
   "contributions": [],
-  "gallery": []
+  "gallery": [
+    {
+      "url": "https://twitter.com/jack_daniel/status/1438168794145431559",
+      "title": "jack_daniel memorial tweet",
+      "caption": ""
+    },
+    {
+      "url": "https://twitter.com/Gillis57/status/1438171256885370883",
+      "title": "Gillis57 memorial tweet",
+      "caption": ""
+    },
+    {
+      "url": "https://twitter.com/spridel11/status/1438302359008919553",
+      "title": "spridel11 memorial tweet (with photo)",
+      "caption": ""
+    }
+  ]
 }

--- a/people/jaimecochran.json
+++ b/people/jaimecochran.json
@@ -15,6 +15,10 @@
       "siteurl": "https://www.twitter.com/ACKFlags"
     },
     {
+      "sitename": "Twitter",
+      "siteurl": "https://twitter.com/asshurtmacfags"
+    },
+    {
       "sitename": "Github",
       "siteurl": "https://github.com/asshurtmacfags"
     },
@@ -27,8 +31,12 @@
       "siteurl": "https://github.com/compoterhacker"
     },
     {
-      "sitename": "Other",
+      "sitename": "Vice",
       "siteurl": "https://www.vice.com/en_uk/article/nn4gvk/rustle-league-are-making-sure-trolling-stays-funny"
+    },
+    {
+      "sitename": "MuckRock FOIA",
+      "siteurl": "https://www.muckrock.com/foi/united-states-of-america-10/jamie-aka-ackflags-47588/"
     }
   ],
   "contributions": [
@@ -48,6 +56,16 @@
       "url": "/images/JaimeCochran.jpg",
       "title": "Jaime Cochran",
       "caption": "Jaime Cochran sitting at her computer"
+    },
+    {
+      "url": "https://www.reddit.com/r/Drama/comments/7psp0p/one_of_the_internets_most_infamous_trolls_jaime/",
+      "title": "Reddit thread about Jaime",
+      "caption": ""
+    },
+    {
+      "url": "https://www.blogtalkradio.com/canadianglen/2018/01/17/rustle-league-radio-remembers-asshurtmacfags",
+      "title": "Rustle League Radio memorial",
+      "caption": ""
     }
   ]
 }

--- a/people/kellylum.json
+++ b/people/kellylum.json
@@ -54,6 +54,26 @@
       "url": "/images/Kelly_Lum4.jpg",
       "title": "Photo of Kelly Lum on Halloween 2015",
       "caption": "Photo of Kelly Lum on Halloween 2015"
+    },
+    {
+      "url": "https://twitter.com/SummerC0n/status/1637988841926672384",
+      "title": "SummerCon memorial tweet",
+      "caption": ""
+    },
+    {
+      "url": "https://vimeo.com/845798078/740f695ed7",
+      "title": "SummerCon memorial video",
+      "caption": ""
+    },
+    {
+      "url": "https://www.darkreading.com/application-security/renowned-researcher-kelly-lum-passes-away",
+      "title": "Dark Reading obituary",
+      "caption": ""
+    },
+    {
+      "url": "https://www.fox5ny.com/news/lack-of-women-in-cyber-security",
+      "title": "Fox5 NY news piece",
+      "caption": ""
     }
   ]
 }

--- a/people/michaelhawley.json
+++ b/people/michaelhawley.json
@@ -7,13 +7,24 @@
   "obituary": "https://news.mit.edu/2020/michael-hawley-former-professor-media-arts-sciences-dies-0625",
   "issue": "155",
   "affiliations": "",
-  "mainimage": "images/michael_hawley01.jpg",
+  "mainimage": "/images/michael_hawley01.jpg",
   "maintext": "Hawley participated in some of the great digital breakthroughs of the last 40 years, from writing UNIX code at Bell Labs as a teenager, to his work pioneering digital cinema and sound technology at LucasFilm, to his innovation of large-imprint digital photo systems, which led to the 2003 publication of 'Bhutan: A Visual Odyssey Across the Last Himalayan Kingdom,' measuring 5’ x 7’ and weighing over 150 pounds, giving it the distinction of being documented as the world’s largest published book in the 'Guinness Book of World Records.'",
   "socialmedialinks": [],
-  "contributions": [],
+  "contributions": [
+    {
+      "title": "New York Times obituary",
+      "url": "https://www.nytimes.com/2020/06/24/technology/michael-hawley-dead.html",
+      "description": "NYT obituary covering his achievements from UNIX code at Bell Labs to digital cinema at LucasFilm to publishing the world's biggest book."
+    },
+    {
+      "title": "MIT Media Lab memorial",
+      "url": "https://www.media.mit.edu/videos/mike-hawley-fest-2020-04-21/",
+      "description": "MIT Media Lab memorial video for Michael Hawley."
+    }
+  ],
   "gallery": [
     {
-      "url": "images/michael_hawley02.jpg",
+      "url": "/images/michael_hawley02.jpg",
       "title": "Photo of Michael Hawley",
       "caption": "Photo of Michael Hawley"
     }


### PR DESCRIPTION
## Summary
- **Kelly Lum (#194):** Add SummerCon memorial tweet/video, Dark Reading obituary, Fox5 news links
- **Jaime Cochran (#26):** Add @asshurtmacfags Twitter, MuckRock FOIA, Reddit thread, Rustle League Radio memorial
- **Aaron Swartz (#7):** Add Wikipedia and MuckRock FBI FOIA links
- **Christian Wright (#11):** Add SecLists ISN posting and GoFundMe memorial
- **Dan Kaminsky (#169):** Add NYT obituary, Slashdot article, The Parallax article, talks list tweet
- **Michael Hawley (#155):** Fix broken image paths (missing leading `/`), add NYT obituary and MIT Media Lab memorial video
- **Glenn Eccard (#183):** Add 3 memorial tweets from issue
- **Chris Hurley (#192):** Add Security Tribe and Goon Band to affiliations
- **Ben Byer (#31):** Add fail0verflow memorial blog post
- **Bruce Esquibel (#193):** Add textfiles and DethVeggie memorial tweets
- **Geoffrey Bennett (#33):** Add TICOM, Inc. affiliation and DOJ letter contribution

## Test plan
- [ ] Verify Michael Hawley images now render (leading slash fix)
- [ ] Spot-check new links are valid
- [ ] Run `rake build` to confirm site builds

## Summary by Sourcery

Update memorial and affiliation data for multiple individuals based on additional sources and issue comments.

New Features:
- Add new memorial links, obituaries, videos, FOIA documents, and discussion threads to several individuals’ records.
- Add new affiliations and contribution details for certain individuals.

Bug Fixes:
- Correct broken image paths for Michael Hawley so images render correctly.

Enhancements:
- Expand existing person records with richer contextual information from external references and social media memorials.