### PR TITLE
fix(data): add missing maintext bios for 5 memorial entries

### DIFF
--- a/people/aarontesterman.json
+++ b/people/aarontesterman.json
@@ -8,7 +8,7 @@
   "issue": "135",
   "affiliations": "",
   "mainimage": "/images/face-silhouette-clipart.png",
-  "maintext": "",
+  "maintext": "<p>Aaron Testerman was a member of the information security community. He was born on March 17, 1978 and passed away on May 11, 2020 in Colton, California at the age of 42.</p>",
   "socialmedialinks": [],
   "contributions": [],
   "gallery": []

--- a/people/conorfaheylatrope.json
+++ b/people/conorfaheylatrope.json
@@ -8,7 +8,7 @@
   "issue": "81",
   "affiliations": "",
   "mainimage": "/images/Conor_Fahey-Latrope.jpg",
-  "maintext": "",
+  "maintext": "<p>Conor Fahey-Latrope, known as Conor Pot Pie, worked at BitTorrent. He was a member of the hacker and information security community.</p>",
   "socialmedialinks": [
     {
       "sitename": "Twitter",

--- a/people/ericchavez.json
+++ b/people/ericchavez.json
@@ -8,7 +8,7 @@
   "issue": "57",
   "affiliations": "",
   "mainimage": "/images/Eric_Chavez.jpg",
-  "maintext": "",
+  "maintext": "<p>Eric Chavez was a member of the information security community. He passed away in 2019.</p>",
   "socialmedialinks": [
     {
       "sitename": "LinkedIn",
@@ -21,6 +21,16 @@
       "url": "/images/Eric_Chavez-linkedin.jpg",
       "title": "LinkedIn Profile Photo",
       "caption": "LinkedIn Profile Photo"
+    },
+    {
+      "url": "https://twitter.com/andrewsmhay/status/1154837713964732418",
+      "title": "Andrew Hay memorial tweet",
+      "caption": ""
+    },
+    {
+      "url": "https://twitter.com/andrewsmhay/status/1155294438807285760",
+      "title": "Andrew Hay memorial tweet",
+      "caption": ""
     }
   ]
 }

--- a/people/johnhortonconway.json
+++ b/people/johnhortonconway.json
@@ -8,7 +8,7 @@
   "issue": "134",
   "affiliations": "",
   "mainimage": "/images/face-silhouette-clipart.png",
-  "maintext": "",
+  "maintext": "<p>John Horton Conway was a British mathematician born December 26, 1937 in Liverpool, England. He was a professor at Cambridge University before becoming the John von Neumann Professor of Applied and Computational Mathematics at Princeton University.</p><p>Conway made foundational contributions across an extraordinary range of mathematics, including combinatorial game theory, knot theory, number theory, coding theory, and group theory. He is perhaps best known for inventing the Game of Life cellular automaton, which became a cornerstone of recreational mathematics and computer science. He co-invented surreal numbers, contributed to the classification of finite simple groups (the Conway groups), and authored landmark works including 'On Numbers and Games' and 'Winning Ways for Your Mathematical Plays.' Over twenty mathematical concepts bear his name.</p><p>Conway died on April 11, 2020 in New Brunswick, New Jersey from complications of COVID-19. He was 82.</p>",
   "socialmedialinks": [
     {
       "sitename": "Wikipedia",

--- a/people/michaelassante.json
+++ b/people/michaelassante.json
@@ -6,9 +6,9 @@
   "death": "2019",
   "obituary": "",
   "issue": "10",
-  "affiliations": "",
+  "affiliations": "SANS, NERC, Idaho National Laboratory",
   "mainimage": "https://images.idgesg.net/images/article/2019/06/mike-assante_cyber-security-guru_by-ryan-g-poirier-100799482-large.jpg",
-  "maintext": "",
+  "maintext": "<p>Michael J. Assante was a pioneering figure in industrial control system (ICS) and critical infrastructure cybersecurity. He served as CISO at American Electric Power during the 2003 Northeast blackout, became the first Chief Security Officer at the North American Electric Reliability Corporation (NERC), and led groundbreaking research at Idaho National Laboratory where he assembled the interdisciplinary teams that demonstrated SCADA/ICS vulnerabilities.</p><p>Assante co-founded NameLogiKeep, Inc. and developed IntelliShield, later acquired by Cisco. He co-authored the ICS Cyber Kill Chain framework with Robert Lee, served on the Commission on Cyber Security for the 44th Presidency, and received the RSA 2005 Outstanding Achievement Award. He co-led the creation of the GICSP certification, now held by over 1,300 practitioners in more than 30 countries, and led SANS ICS/SCADA security initiatives, receiving the SANS ICS Lifetime Achievement Award in 2018.</p><p>Assante passed away on July 5, 2019 at the age of 48 after a long battle with lymphoma.</p>",
   "socialmedialinks": [
     {
       "sitename": "Twitter",


### PR DESCRIPTION
## Summary
- **John Horton Conway (#134):** Full bio covering Cambridge/Princeton career, Game of Life, surreal numbers, group theory contributions, COVID-19 death
- **Michael Assante (#10/#61):** Full bio covering ICS/SCADA security career at NERC, Idaho National Lab, ICS Cyber Kill Chain co-authorship, GICSP certification, SANS lifetime achievement, lymphoma
- **Aaron Testerman (#135):** Minimal bio from sparse issue data (no comments, obituary URL returns 403)
- **Eric Chavez (#57):** Minimal bio, added 2 Andrew Hay memorial tweets to gallery
- **Conor Fahey-Latrope (#81):** Minimal bio noting BitTorrent employment

Note: Testerman, Chavez, and Fahey-Latrope have very little data available in their issues. Their bios are placeholders until community members contribute more information.

## Test plan
- [ ] Verify Conway and Assante memorial pages render full bios
- [ ] Verify minimal bios display correctly for the other 3
- [ ] Run `rake build` to confirm site builds

## Summary by Sourcery

Add missing memorial biography main text entries for several people records in the data set.

Enhancements:
- Populate full maintext bios for John Horton Conway and Michael Assante memorial entries.
- Add placeholder maintext bios for Aaron Testerman, Eric Chavez, and Conor Fahey-Latrope memorial entries, including new memorial gallery items where available.

Chores:
- Correct and complete content in multiple memorial JSON data files without changing site behavior or structure.