### PR TITLE
fix(data): normalize kelvinwhite.json to match repo conventions

### DIFF
--- a/people/kelvinwhite.json
+++ b/people/kelvinwhite.json
@@ -8,7 +8,7 @@
   "issue": "128",
   "affiliations": "SmashTheStack",
   "mainimage": "/images/kelvin_white_l3thal.jpeg",
-  "maintext": "Kelvin White (a.k.a. l3thal) graced the world with his presence for just 39 years, but he lived every moment of it to the max. If you were lucky enough to meet him, you either instantly connected or not, with no awkward stage in between.",
+  "maintext": "<p>Kelvin White (a.k.a. l3thal) graced the world with his presence for just 39 years, but he lived every moment of it to the max. If you were lucky enough to meet him, you either instantly connected or not, with no awkward stage in between.</p>",
   "socialmedialinks": [
     {
       "sitename": "Twitter",
@@ -42,37 +42,37 @@
   ],
   "gallery": [
     {
-      "url": "images/kelvin_white_l3thal_classic_1992_age-15.jpeg",
+      "url": "/images/kelvin_white_l3thal_classic_1992_age-15.jpeg",
       "title": "Classic Kelvin. *swoon* (circa 1992, age 15)",
       "caption": "Photo of l3thal at age 15 (1992)"
     },
     {
-      "url": "images/kelvin_white_l3thal_keyboard.jpeg",
+      "url": "/images/kelvin_white_l3thal_keyboard.jpeg",
       "title": "l3thal avatar",
       "caption": "Photo of l3thal wearing a mask and holding a keyboard like a rifle"
     },
     {
-      "url": "images/kelvin_white_l3thal_last-known-photo.jpeg",
+      "url": "/images/kelvin_white_l3thal_last-known-photo.jpeg",
       "title": "Last known photo: 4/15 12am. Crazy as always.",
       "caption": "The last known photo of l3thal"
     },
     {
-      "url": "images/kelvin_white_l3thal_memorial_banner.png",
+      "url": "/images/kelvin_white_l3thal_memorial_banner.png",
       "title": "Memorial banner (l3thal edit)",
       "caption": "A memorial banner of multiple photos in honor of l3thal"
     },
     {
-      "url": "images/kelvin_white_l3thal_punk.jpeg",
+      "url": "/images/kelvin_white_l3thal_punk.jpeg",
       "title": "That perfect punk snarl.",
       "caption": "Photo of l3thal dressed in his usual punk attire"
     },
     {
-      "url": "images/kelvin_white_l3thal_STS-at-DEFCON.jpeg",
+      "url": "/images/kelvin_white_l3thal_STS-at-DEFCON.jpeg",
       "title": "Photo of l3thal (front/center hugging mauvehed) and other anonymous SmashTheStack members at DEF CON",
       "caption": "Photo of l3thal (front/center hugging mauvehed) and other anonymous SmashTheStack members at DEF CON"
     },
     {
-      "url": "images/kelvin_white_star-struck.jpeg",
+      "url": "/images/kelvin_white_star-struck.jpeg",
       "title": "Love in our star-struck eyes, immortalized. (either that or we mighta been smacked out that night)",
       "caption": "Photo of Kelvin and wife Kelli"
     }


### PR DESCRIPTION
## Summary

- Gallery image URLs now use leading `/` like the other 97 entries
- `maintext` wrapped in `<p>` to match the formatting of other bios

No visual regression in production — `safeUrl()` already resolved the relative URLs correctly. This is a consistency/defensive cleanup.

## Test plan

- [x] Visit Kelvin White's memorial — all 7 gallery images load, bio renders as a paragraph

## Summary by Sourcery

Normalize Kelvin White memorial data to match existing people entry conventions.

Enhancements:
- Standardize Kelvin White gallery image URLs to use leading slashes for consistency with other entries.
- Wrap Kelvin White's main biography text in a paragraph tag to align with existing bio formatting.